### PR TITLE
Project tuning

### DIFF
--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -2,9 +2,7 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:10-stretch-run
 # Defines our working directory in container
 WORKDIR /usr/src/app
 
-RUN apt-get update && \
-    apt-get install -yq wget && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN install_packages wget
 
 ENV JQUERY_VERSION=3.3.1
 ENV REQUIREJS_VERSION=2.3.5

--- a/haproxy/Dockerfile.aarch64
+++ b/haproxy/Dockerfile.aarch64
@@ -1,3 +1,3 @@
-FROM arm64v8/haproxy:1.8.0-alpine
+FROM arm64v8/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.amd64
+++ b/haproxy/Dockerfile.amd64
@@ -1,3 +1,3 @@
-FROM haproxy:1.8.0-alpine
+FROM haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.armhf
+++ b/haproxy/Dockerfile.armhf
@@ -1,3 +1,3 @@
-FROM arm32v6/haproxy:1.8.0-alpine
+FROM arm32v6/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.armv7hf
+++ b/haproxy/Dockerfile.armv7hf
@@ -1,3 +1,3 @@
-FROM arm32v6/haproxy:1.8.0-alpine
+FROM arm32v6/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.i386
+++ b/haproxy/Dockerfile.i386
@@ -1,3 +1,3 @@
-FROM i386/haproxy:1.8.0-alpine
+FROM i386/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.i386-nlp
+++ b/haproxy/Dockerfile.i386-nlp
@@ -1,3 +1,3 @@
-FROM i386/haproxy:1.8.0-alpine
+FROM i386/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy/Dockerfile.rpi
+++ b/haproxy/Dockerfile.rpi
@@ -1,3 +1,3 @@
-FROM arm32v6/haproxy:1.8.0-alpine
+FROM arm32v6/haproxy:1-alpine
 
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
From the commit messages:

haproxy: use just major version of haproxy to be more up to date
    
    Haproxy is now on 1.9.6, and using the images defined by just the
    major part of the semver should allow getting updates (e.g. from
    the previously defined 1.8.0), while not breaking things, as long
    as haproxy is using major version designation correctly (of no
    breaking changes within major numbers, just between them)

frontend: use "install_packages" tool to install packages