### PR TITLE
frontend: highchart version was rolling before, pin it

### DIFF
--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -6,9 +6,10 @@ RUN install_packages wget
 
 ENV JQUERY_VERSION=3.3.1
 ENV REQUIREJS_VERSION=2.3.5
+ENV HIGHCHARTS_VERSION=7.0.3
 RUN mkdir -p static/js && \
     wget "https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js" -O static/js/jquery.min.js && \
-    wget https://code.highcharts.com/highcharts.js -O static/js/highcharts.js && \
+    wget "https://code.highcharts.com/${HIGHCHARTS_VERSION}/highcharts.js" -O static/js/highcharts.js && \
     wget "http://requirejs.org/docs/release/${REQUIREJS_VERSION}/minified/require.js" -O static/js/require.js
 
 # Copies the package.json first for better cache on later pushes


### PR DESCRIPTION
Highcharts' rolling version broke this project, as version 7.1.0 does not work correctly.
Pin it to the last 7.0.3 version, that is working as of for sure.

Signed-off-by: Gergely Imreh <gergely@balena.io>